### PR TITLE
Support 32-bit depth in output files

### DIFF
--- a/audacity/__main__.py
+++ b/audacity/__main__.py
@@ -11,8 +11,9 @@ from . import Aup
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("--channel", type=int, default=1)
+    p.add_argument("--bitdepth", type=int, default=16, choices=[16, 32])
     p.add_argument("aupfile")
     p.add_argument("wavfile")
     args = p.parse_args()
     a = Aup(args.aupfile)
-    a.towav(args.wavfile, args.channel-1)
+    a.towav(args.wavfile, args.channel-1, bit_depth=args.bitdepth)


### PR DESCRIPTION
This is in order to preserve as much of the original float32 quality as
possible.